### PR TITLE
Auth0 のスコープを使うようにする

### DIFF
--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -1,5 +1,9 @@
 import jwt
+import logging
 from rest_framework import permissions
+
+
+logger = logging.getLogger(__name__)
 
 
 class IsPermittedScope(permissions.BasePermission):
@@ -14,7 +18,7 @@ class IsPermittedScope(permissions.BasePermission):
             decoded = jwt.decode(token, verify=False)
             if decoded.get('scope'):
                 token_scopes = decoded['scope'].split()
-                return 'read:examples' in token_scopes
+                return self.required_scope in token_scopes
 
     def get_token_auth_header(self, request):
         auth = request.META.get('HTTP_AUTHORIZATION', None)

--- a/examples/views.py
+++ b/examples/views.py
@@ -12,5 +12,4 @@ logger = logging.getLogger(__name__)
 class IndexViewSet(viewsets.ModelViewSet):
     queryset = Example.objects.all()
     serializer_class = ExampleSerializer
-    # FIXME: Scope の設定がうまくいかない(…今回は必要ないけど)
-    # permission_classes = [permissions.ReadExamplesScope]
+    permission_classes = [permissions.ReadExamplesScope]

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,4 @@
 VUE_APP_AUTH0_DOMAIN=dev-9t4hfnwv.auth0.com
 VUE_APP_AUTH0_CLIENT_ID=qnIgE4YVtspIvchuf4VXnbSEO1ekTY3Z
-VUE_APP_AUTH0_SCOPE="openid profile read:examples"
+VUE_APP_AUTH0_SCOPE="openid profile email read:examples"
 VUE_APP_BACKEND_API_URL="/api"

--- a/frontend/src/persister.ts
+++ b/frontend/src/persister.ts
@@ -14,7 +14,9 @@ const SCOPE = process.env.VUE_APP_AUTH0_SCOPE;
 const url = (path: string) => `${BACKEND_URL}/${path.replace(/^\//, '')}`;
 
 function getTokenSilently() {
-  return Vue.prototype.$auth.getTokenSilently.call(Vue.prototype);
+  return Vue.prototype.$auth.getTokenSilently.call(Vue.prototype, {
+    scope: SCOPE,
+  });
 }
 
 class Resource {

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   devServer: {
     proxy: 'http://app:8080',
+    public: 'toutobu-annotator.local:3333',
+    https: true,
   },
 };


### PR DESCRIPTION
closes #13.

色々やったけどあまり覚えていない…たしかここら辺を修正したと思う

* server の examples.permission を利用するようにした
* fronend から scope の情報を付与するようにした
* google-oauth2 の dev じゃない版を新規作成した
* /etc/hosts に toutobu-annotator.local を追加
    * consent 周りで localhost じゃうまくいかないため
* dev-server で localhost じゃなくなったことへの対応
* auth0-spa-js で怒るので、dev-server で https を設定

つうか、Auth0 まともに使うの無茶苦茶大変じゃないか？？？？